### PR TITLE
Update group management and display in tournament view

### DIFF
--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Group extends Model
+{
+    use HasFactory;
+
+    protected static $unguarded = [];
+
+    public function pool(): BelongsTo
+    {
+        return $this->belongsTo(Pool::class, 'pool_id', 'id');
+    }
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class, 'team_id', 'team_official_id');
+    }
+
+    public function scopeTeamIds($query)
+    {
+        return $query->where('group_name', $this->group_name);
+    }
+}

--- a/app/Models/Pool.php
+++ b/app/Models/Pool.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Pool extends Model
 {
@@ -14,4 +15,9 @@ class Pool extends Model
     protected $casts = [
         'groups' => 'array',
     ];
+
+    public function groups(): HasMany
+    {
+        return $this->hasMany(Group::class, 'pool_id', 'id');
+    }
 }

--- a/database/migrations/2023_12_22_102825_create_groups_table.php
+++ b/database/migrations/2023_12_22_102825_create_groups_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('groups', function (Blueprint $table) {
+            $table->id();
+            $table->string('group_name');
+            $table->unsignedBigInteger('team_id');
+            $table->unsignedBigInteger('pool_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('groups');
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "sports_records",
+    "name": "sports-records",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/views/filament/pages/pool.blade.php
+++ b/resources/views/filament/pages/pool.blade.php
@@ -1,17 +1,13 @@
 <x-filament::page>
     {{-- <script src="https://cdn.tailwindcss.com" defer></script> --}}
-
    <section>
     <article class=" mx-auto max-w-screen-xl px-4 py-8 sm:px-6 ">
-
-        {{-- @foreach ($record->group as $item)
-
-        <p>{{ $item }}</p>
-
-        @endforeach --}}
-
-
+        @foreach ($record->groups()->with('team')->select('group_name')->distinct()->get() as $group)
+            <div class="border border-2" style="margin-bottom: 10px">
+                <h1>{{ $group->group_name }}</h1>
+                <p>{{ \App\Models\Group::where('group_name', $group->group_name)->with('team')->get()->pluck('team.team_name')->implode(', ') }}</p>
+            </div>
+        @endforeach
     </article>
    </section>
-
 </x-filament::page>


### PR DESCRIPTION
Implemented changes to both backend logic and frontend display for tournament groups. A new `Group` model and corresponding migration were created to better manage group data. Adjustments were also made in `ViewTournament.php` for the group creation process. In the frontend, `pool.blade.php` was improved to display individual group names and their respective teams.